### PR TITLE
feat: Micropostの最大文字数を140文字に制限する

### DIFF
--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,5 +1,5 @@
 class Micropost < ApplicationRecord
   belongs_to :user
-  validates :content, length: { maximum: 140 },
-                      presence: true
+  validates :content, length: { maximum: 140 }, # 140文字の文字数制限
+                      presence: true # マイクロポストのコンテンツの存在確認
 end


### PR DESCRIPTION
close: https://github.com/zskteam-20210209-102645/zsksample_rails01/issues/15

## 概要

- Micropostの最大文字数を140文字に制限する

## 修正内容の検証方法

- Micropostに141文字以上を入力する。

## この修正が正しい理由

- 特になしです。