### PR TITLE
feat: UserとMicropostを1対多の関係にする

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_many :microposts
   validates :name,  presence: true, length: { maximum: 50 }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
   validates :email, presence: true, length: { maximum: 255 },


### PR DESCRIPTION
close: https://github.com/zskteam-20210209-102645/zsksample_rails01/issues/16

## 概要

- User が 複数のMicropostと関連付きます。

## 修正内容の検証方法

- User を指定して、たくさんMicropostを投稿します。

## この修正が正しい理由

- ユーザーがマイクロポストを複数所有する (has_many) 関連付けを行いました。
