### PR TITLE
test: microposts_destroy_spec

### DIFF
--- a/spec/requests/microposts_destroy_spec.rb
+++ b/spec/requests/microposts_destroy_spec.rb
@@ -10,7 +10,7 @@ describe MicropostsController, type: :system do
    response
   end
   it { is_expected.to have_http_status(:ok) }
-  it 'マイクロポストに'Destroy'のリンクがあることを確認する' do
+  it 'マイクロポストにDestroyのリンクがあることを確認する' do
    expect(action.body).to have_link 'Destroy'
   end
  end

--- a/spec/requests/microposts_destroy_spec.rb
+++ b/spec/requests/microposts_destroy_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+describe MicropostsController, type: :system do
+ let(:user) { FactoryBot.build(:user) }
+ before do
+  @micropost1 = FactoryBot.create(:micropost, user: user)
+ end
+ describe 'GET #destroy' do
+  subject(:action) do
+   get microposts_path
+   response
+  end
+  it { is_expected.to have_http_status(:ok) }
+  it 'マイクロポストに「削除」ボタンがあることを確認する' do
+   expect(action.body).to have_link 'Destroy'
+  end
+ end
+end

--- a/spec/requests/microposts_destroy_spec.rb
+++ b/spec/requests/microposts_destroy_spec.rb
@@ -10,7 +10,7 @@ describe MicropostsController, type: :system do
    response
   end
   it { is_expected.to have_http_status(:ok) }
-  it 'マイクロポストに「削除」ボタンがあることを確認する' do
+  it 'マイクロポストに'Destroy'のリンクがあることを確認する' do
    expect(action.body).to have_link 'Destroy'
   end
  end


### PR DESCRIPTION
close #14 

## 概要

Micropostリクエストについて、Destroy のテストを追加。

## 修正内容の検証方法

- この修正を検証するための実行手順等
コンソールでbundle exec rspec spec/requests/microposts_destroy_spec.rb入力
## この修正が正しい理由

- この修正が正しい理由
- テストが正常に完了する
