### PR TITLE
feat: Active storage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,7 +28,12 @@ Metrics/AbcSize:
   # The ABC size is a calculated magnitude, so this number can be a Fixnum or
   # a Float.
   Max: 20 
-  
+
+Metrics/MethodLength:
+  Enabled: false
+  CountComments: false  # count full line comments?
+  Max: 100
+
 Layout/LineLength:
   Enabled: false
 Layout/EmptyLinesAroundAttributeAccessor:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,7 +23,12 @@ Style/FrozenStringLiteralComment:
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
-    
+
+Metrics/AbcSize:
+  # The ABC size is a calculated magnitude, so this number can be a Fixnum or
+  # a Float.
+  Max: 20 
+  
 Layout/LineLength:
   Enabled: false
 Layout/EmptyLinesAroundAttributeAccessor:

--- a/Gemfile
+++ b/Gemfile
@@ -26,10 +26,9 @@ gem 'bootstrap-will_paginate', '1.0.0'
 gem 'faker', '2.1.2'
 gem 'will_paginate', '3.1.8'
 
-
-
-gem 'mini_magick'
+# Use ActiveStorage
 gem 'image_processing', '~> 1.2'
+gem 'mini_magick'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,11 @@ gem 'bootstrap-will_paginate', '1.0.0'
 gem 'faker', '2.1.2'
 gem 'will_paginate', '3.1.8'
 
+
+
+gem 'mini_magick'
+gem 'image_processing', '~> 1.2'
+
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 

--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -70,6 +70,6 @@ class MicropostsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def micropost_params
-    params.require(:micropost).permit(:content, :user_id)
+    params.require(:micropost).permit(:content, :user_id, :image)
   end
 end

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -5,6 +5,7 @@ class Micropost < ApplicationRecord
   validates :content, length: { maximum: 140 }, presence: true, unless: :was_attached?
 
   def was_attached?
-    self.image.attached?
+    # self.image.attached? [Checkのエラーが発生: Style/RedundantSelf: Redundant self detected.]
+    image.attached?
   end
 end

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -5,7 +5,6 @@ class Micropost < ApplicationRecord
   validates :content, length: { maximum: 140 }, presence: true, unless: :was_attached?
 
   def was_attached?
-    # self.image.attached? [Checkのエラーが発生: Style/RedundantSelf: Redundant self detected.]
-    image.attached?
+    image.attached? # self.image.attached? の場合、[Checkのエラーが発生: Style/RedundantSelf: Redundant self detected.]
   end
 end

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,5 +1,10 @@
 class Micropost < ApplicationRecord
+  has_one_attached :image
   belongs_to :user
-  validates :content, length: { maximum: 140 },
-                      presence: true
+
+  validates :content, length: { maximum: 140 }, presence: true, unless: :was_attached?
+
+  def was_attached?
+    self.image.attached?
+  end
 end

--- a/app/views/microposts/_form.html.erb
+++ b/app/views/microposts/_form.html.erb
@@ -21,6 +21,10 @@
     <%= form.number_field :user_id %>
   </div>
 
+  <div class="content_post" >
+    <%= form.file_field :image %><br>
+  </div>
+
   <div class="actions">
     <%= form.submit %>
   </div>

--- a/app/views/microposts/show.html.erb
+++ b/app/views/microposts/show.html.erb
@@ -10,5 +10,9 @@
   <%= @micropost.user_id %>
 </p>
 
+<% if @micropost.image.attached? %>
+  <%= image_tag @micropost.image %>
+<% end %>
+
 <%= link_to 'Edit', edit_micropost_path(@micropost) %> |
 <%= link_to 'Back', microposts_path %>

--- a/app/views/microposts/show.html.erb
+++ b/app/views/microposts/show.html.erb
@@ -11,7 +11,7 @@
 </p>
 
 <% if @micropost.image.attached? %>
-  <%= image_tag @micropost.image %>
+  <%= image_tag @micropost.image.variant(resize: '500x500') %>
 <% end %>
 
 <%= link_to 'Edit', edit_micropost_path(@micropost) %> |

--- a/db/migrate/20210312051109_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20210312051109_create_active_storage_tables.active_storage.rb
@@ -1,5 +1,5 @@
 # This migration comes from active_storage (originally 20170806125915)
-class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+class CreateActiveStorageTables < ActiveRecord::Migration[6.0]
   def change
     create_table :active_storage_blobs do |t|
       t.string   :key,        null: false

--- a/db/migrate/20210312051109_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20210312051109_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/migrate/20210312051109_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20210312051109_create_active_storage_tables.active_storage.rb
@@ -10,7 +10,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.string   :checksum,   null: false
       t.datetime :created_at, null: false
 
-      t.index[:key], unique: true
+      t.index :key, unique: true
     end
 
     create_table :active_storage_attachments do |t|
@@ -20,7 +20,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
 
       t.datetime :created_at, null: false
 
-      t.index[:record_type, :record_id, :name,:blob_id], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.index :record_type, :record_id, :name, :blob_id, name: "index_active_storage_attachments_uniqueness", unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end

--- a/db/migrate/20210312051109_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20210312051109_create_active_storage_tables.active_storage.rb
@@ -20,7 +20,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
 
       t.datetime :created_at, null: false
 
-      t.index[:record_type,:record_id,:name,:blob_id], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.index[:record_type, :record_id, :name,:blob_id], name: "index_active_storage_attachments_uniqueness", unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end

--- a/db/migrate/20210312051109_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20210312051109_create_active_storage_tables.active_storage.rb
@@ -20,7 +20,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
 
       t.datetime :created_at, null: false
 
-      t.index :record_type, :record_id, :name, :blob_id, name: "index_active_storage_attachments_uniqueness", unique: true
+      t.index :record_type, :record_id, :name, :blob_id, name: index_active_storage_attachments_uniqueness, unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end

--- a/db/migrate/20210312051109_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20210312051109_create_active_storage_tables.active_storage.rb
@@ -10,7 +10,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.string   :checksum,   null: false
       t.datetime :created_at, null: false
 
-      t.index [ :key ], unique: true
+      t.index[:key], unique: true
     end
 
     create_table :active_storage_attachments do |t|
@@ -20,7 +20,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
 
       t.datetime :created_at, null: false
 
-      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.index[:record_type,:record_id,:name,:blob_id], name: "index_active_storage_attachments_uniqueness", unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end


### PR DESCRIPTION
close https://github.com/zskteam-20210209-102645/zsksample_rails01/issues/19

## 概要

- 画像の投稿ができるようになります。

## 修正内容の検証方法

以下の４手順を踏んでください。

- ①以下のコマンドで、imagemagickをインストールしてください。
% brew install imagemagick  

　　ローカルに、画像加工のために必要なImageMagickという画像変換ツールが必要です。


- ②以下のコマンドで、Gem をインストールしてください
% bundle install

　　Gemfileにて、以下のGemが追記されています。
　　gem 'mini_magick'
　　gem 'image_processing', '~> 1.2'


- ③以下のコマンドで、Active Storageを使うためにインストールしてください。
% rails active_storage:install

- ④Active Storageのテーブルをマイグレートしてください。
% rails db:migrate


以上でActiceStorageの準備が整います。



## 補足

- rails s を打つと、warning が出ます。これは、Ruby 2.7 が Gemが対応していないことによるものです。

% rails s
=> Booting Puma
=> Rails 6.0.3.2 application starting in development 
=> Run `rails server --help` for more startup options
/private/var/www/rails/zsksample_rails01_Yeah/vendor/bundle/ruby/2.7.0/gems/faker-2.1.2/lib/faker.rb:155: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/private/var/www/rails/zsksample_rails01_Yeah/vendor/bundle/ruby/2.7.0/gems/i18n-1.8.9/lib/i18n.rb:196: warning: The called method `translate' is defined here

複数のサイトで対応策を探しましたが、根本的な解決には至りませんでした。
代わりに、エラーログを表示させなくするという方法が見つかりました。
（参考；https://k-koh.hatenablog.com/entry/2020/01/21/211130）

メソッドを実行することは可能なため、warning を表示させるかどうかは各自の判断にお任せ致します。
ご助言ございましたらお知らせください。