### PR TITLE
feat: ActiveStorage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,13 @@ Style/FrozenStringLiteralComment:
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
+
+Metrics/AbcSize
+  Max: 20
+
+MethodLength:
+  CountComments: false  # count full line comments?
+  Max: 20
     
 Layout/LineLength:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,7 +24,7 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
 
-Metrics/AbcSize
+Metrics/AbcSize:
   Max: 20
 
 MethodLength:

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,9 @@ gem 'bootstrap-will_paginate', '1.0.0'
 gem 'faker', '2.1.2'
 gem 'kaminari'
 gem 'will_paginate', '3.1.8'
+# Use ActiveStorage
+gem 'image_processing', '~> 1.2'
+gem 'mini_magick'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,10 +128,12 @@ GEM
     mimemagic (0.3.5)
     mini_magick (4.11.0)
     mini_mime (1.0.2)
+    mini_portile2 (2.5.0)
     minitest (5.14.4)
     msgpack (1.4.2)
     nio4r (2.5.7)
-    nokogiri (1.11.1-x86_64-darwin)
+    nokogiri (1.11.2)
+      mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     parallel (1.20.1)
     parser (3.0.0.0)
@@ -273,7 +275,6 @@ GEM
 
 PLATFORMS
   ruby
-  x86_64-darwin-19
 
 DEPENDENCIES
   bootsnap (= 1.4.6)
@@ -310,4 +311,4 @@ RUBY VERSION
    ruby 2.7.1p83
 
 BUNDLED WITH
-   2.2.14
+   2.2.11

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,9 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.1)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     kaminari (1.2.1)
@@ -123,6 +126,7 @@ GEM
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
     mimemagic (0.3.5)
+    mini_magick (4.11.0)
     mini_mime (1.0.2)
     minitest (5.14.4)
     msgpack (1.4.2)
@@ -208,6 +212,8 @@ GEM
       rack (>= 1.1)
       rubocop (>= 0.82.0)
     ruby-progressbar (1.11.0)
+    ruby-vips (2.1.0)
+      ffi (~> 1.12)
     rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -276,9 +282,11 @@ DEPENDENCIES
   capybara (= 3.33.0)
   factory_bot_rails (~> 4.10.0)
   faker (= 2.1.2)
+  image_processing (~> 1.2)
   jbuilder (= 2.10.0)
   kaminari
   listen (= 3.2.1)
+  mini_magick
   pg (= 1.2.3)
   puma (= 4.3.5)
   rails (= 6.0.3.2)
@@ -301,4 +309,4 @@ RUBY VERSION
    ruby 2.7.1p83
 
 BUNDLED WITH
-   2.2.11
+   2.2.14

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,6 +272,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  ruby
   x86_64-darwin-19
 
 DEPENDENCIES

--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -70,6 +70,6 @@ class MicropostsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def micropost_params
-    params.require(:micropost).permit(:content, :user_id)
+    params.require(:micropost).permit(:content, :user_id, :image)
   end
 end

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,5 +1,9 @@
 class Micropost < ApplicationRecord
+  has_one_attached :image
   belongs_to :user
   validates :content, length: { maximum: 140 },
-                      presence: true
+                      presence: true, unless: :was_attached?
+  def was_attached?
+    image.attached?
+  end
 end

--- a/app/views/microposts/_form.html.erb
+++ b/app/views/microposts/_form.html.erb
@@ -21,6 +21,10 @@
     <%= form.number_field :user_id %>
   </div>
 
+  <div class="content_post" >
+    <%= form.file_field :image %><br>
+  </div>
+
   <div class="actions">
     <%= form.submit %>
   </div>

--- a/app/views/microposts/show.html.erb
+++ b/app/views/microposts/show.html.erb
@@ -10,5 +10,9 @@
   <%= @micropost.user_id %>
 </p>
 
+<% if @micropost.image.attached? %>
+  <%= image_tag @micropost.image.variant(resize: '500x500') %>
+<% end %>
+
 <%= link_to 'Edit', edit_micropost_path(@micropost) %> |
 <%= link_to 'Back', microposts_path %>

--- a/db/migrate/20210313032119_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20210313032119_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/migrate/20210313032119_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20210313032119_create_active_storage_tables.active_storage.rb
@@ -10,7 +10,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.string   :checksum,   null: false
       t.datetime :created_at, null: false
 
-      t.index [ :key ], unique: true
+      t.index :key, unique: true
     end
 
     create_table :active_storage_attachments do |t|
@@ -20,7 +20,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
 
       t.datetime :created_at, null: false
 
-      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.index :record_type, :record_id, :name, :blob_id, name: index_active_storage_attachments_uniqueness, unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,4 +30,26 @@ ActiveRecord::Schema.define(version: 2021_02_27_005126) do
     t.index ["email"], name: "idx", unique: true
   end
 
+  create_table :active_storage_blobs do |t|
+    t.string   :key,        null: false
+    t.string   :filename,   null: false
+    t.string   :content_type
+    t.text     :metadata
+    t.bigint   :byte_size,  null: false
+    t.string   :checksum,   null: false
+    t.datetime :created_at, null: false
+
+    t.index :key, unique: true
+  end
+
+  create_table :active_storage_attachments do |t|
+    t.string     :name,     null: false
+    t.references :record,   null: false, polymorphic: true, index: false
+    t.references :blob,     null: false
+
+    t.datetime :created_at, null: false
+
+    t.index :record_type, :record_id, :name, :blob_id, name: index_active_storage_attachments_uniqueness, unique: true
+    t.foreign_key :active_storage_blobs, column: :blob_id
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,26 +30,4 @@ ActiveRecord::Schema.define(version: 2021_02_27_005126) do
     t.index ["email"], name: "idx", unique: true
   end
 
-  create_table :active_storage_blobs do |t|
-    t.string   :key,        null: false
-    t.string   :filename,   null: false
-    t.string   :content_type
-    t.text     :metadata
-    t.bigint   :byte_size,  null: false
-    t.string   :checksum,   null: false
-    t.datetime :created_at, null: false
-
-    t.index :key, unique: true
-  end
-
-  create_table :active_storage_attachments do |t|
-    t.string     :name,     null: false
-    t.references :record,   null: false, polymorphic: true, index: false
-    t.references :blob,     null: false
-
-    t.datetime :created_at, null: false
-
-    t.index :record_type, :record_id, :name, :blob_id, name: index_active_storage_attachments_uniqueness, unique: true
-    t.foreign_key :active_storage_blobs, column: :blob_id
-  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,31 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_27_005126) do
+ActiveRecord::Schema.define(version: 2021_03_13_032119) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "microposts", force: :cascade do |t|
     t.text "content"
@@ -30,4 +51,5 @@ ActiveRecord::Schema.define(version: 2021_02_27_005126) do
     t.index ["email"], name: "idx", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
close https://github.com/zskteam-20210209-102645/zsksample_rails01/issues/19

## 概要

- 画像の投稿ができるようになります。

## 修正内容の検証方法

以下の４手順を踏んでください。

- ①以下のコマンドで、imagemagickをインストールしてください。
% brew install imagemagick  

　　ローカルに、画像加工のために必要なImageMagickという画像変換ツールが必要です。


- ②以下のコマンドで、Gem をインストールしてください
% bundle install

　　Gemfileにて、以下のGemが追記されています。
　　gem 'mini_magick'
　　gem 'image_processing', '~> 1.2'


- ③以下のコマンドで、Active Storageを使うためにインストールしてください。
% rails active_storage:install

- ④Active Storageのテーブルをマイグレートしてください。
% rails db:migrate


以上でActiceStorageの準備が整います。



## 補足

- rails s を打つと、warning が出るようになります。これは、Ruby 2.7 が Gemに対応していないことによるものです。

% rails s
=> Booting Puma
=> Rails 6.0.3.2 application starting in development 
=> Run `rails server --help` for more startup options
/private/var/www/rails/zsksample_rails01_Yeah/vendor/bundle/ruby/2.7.0/gems/faker-2.1.2/lib/faker.rb:155: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/private/var/www/rails/zsksample_rails01_Yeah/vendor/bundle/ruby/2.7.0/gems/i18n-1.8.9/lib/i18n.rb:196: warning: The called method `translate' is defined here

複数のサイトで対応策を探しましたが、根本的な解決には至りませんでした。
代わりに、エラーログを表示させなくするという方法が見つかりました。
（参考；https://k-koh.hatenablog.com/entry/2020/01/21/211130）

メソッドを実行することは可能なため、warning を表示させるかどうかは各自の判断にお任せ致します。
ご助言ございましたらお知らせください。